### PR TITLE
fix(DropdownField) Propagate props down to KogaioDropdown

### DIFF
--- a/src/Form/DropdownField.jsx
+++ b/src/Form/DropdownField.jsx
@@ -6,7 +6,7 @@ import { fieldShape } from './shapes'
 import { Dropdown } from '../Dropdown'
 
 export const DropdownField = ({ options, ...props }) => {
-  const [field, meta, helpers] = useField(props)
+  const [field, , helpers] = useField(props)
 
   const handleChange = useCallback(v => helpers.setValue(v), [helpers])
 
@@ -15,12 +15,19 @@ export const DropdownField = ({ options, ...props }) => {
     [field, options]
   )
 
-  const selectedLabel = selectedOption ? selectedOption.label : undefined
+  const selectedLabel =
+    selectedOption && selectedOption.disabled !== true
+      ? selectedOption.label
+      : undefined
 
   return (
-    <Dropdown onChange={handleChange} label={props.label} value={selectedLabel}>
-      {options.map(({ label, value }) => (
-        <Dropdown.Option key={value} value={value}>
+    <Dropdown
+      onChange={handleChange}
+      label={props.label}
+      value={selectedLabel}
+      {...props}>
+      {options.map(({ id, label, value }) => (
+        <Dropdown.Option key={id || value} value={value}>
           {label}
         </Dropdown.Option>
       ))}
@@ -32,6 +39,7 @@ DropdownField.propTypes = {
   ...fieldShape,
   options: PropTypes.arrayOf(
     PropTypes.shape({
+      id: PropTypes.string,
       label: PropTypes.node,
       value: PropTypes.any
     })


### PR DESCRIPTION
Fix:
 - propagate props to KogaioDropdown to allow errors and validation to be processed correctly

Improvement:
 - if an `id` attribute is supplied to options array elements, allow without an error to have multiple options with the same value (replicate the HTML `select` element behaviour)
- if an `disabled` attribute is supplied to options array elements, do not allow selecting that option.