### PR TITLE
Fix Dropdown  - Dropdown Items are overlapping in Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "ETVAS UI Kit",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/Dropdown/variants.js
+++ b/src/Dropdown/variants.js
@@ -15,6 +15,7 @@ const DEFAULT_DROPDOWN = {
     'border-radius': `${RADII[8]}px ${RADII[8]}px 0 0`
   },
   '.dropdown-item': {
+    flex: '1 0 auto',
     '.dropdown-text': {
       color: colors.text
     },


### PR DESCRIPTION
- **What**: Dropdown items are overlapping 
- **How**: Have a lot of items in the dropdown (over 30)
- **Fix**: Set the `flex-shrink` property to `0` (`1` by default)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>
<img width="801" alt="Screenshot 2020-07-06 at 18 56 38" src="https://user-images.githubusercontent.com/32541444/86613692-9ef68600-bfba-11ea-909f-6b7d2163b5a1.png">
</td><td>
<img width="795" alt="Screenshot 2020-07-06 at 18 56 57" src="https://user-images.githubusercontent.com/32541444/86613695-a0c04980-bfba-11ea-882c-08545b991ef0.png">
</td></tr></table>

