### PR TITLE
ETV-2136 - Expose a EmbededAppCompatibility HOC in EtvasKit

### DIFF
--- a/src/EmbededApp/EmbededAppCompatibility.jsx
+++ b/src/EmbededApp/EmbededAppCompatibility.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { NotCompatible } from '../ErrorPages'
+
+export const EmbededAppCompatibility = ({ children }) => {
+  const incompatibleFeature = compatibilityFeatures.find(f => !f.isCompatible)
+
+  if (incompatibleFeature) {
+    return <NotCompatible feature={incompatibleFeature} />
+  }
+
+  return children
+}
+
+/*
+  The minimum list of required features that the
+  app needs in order to function properly
+*/
+const compatibilityFeatures = [
+  global => ({
+    name: 'sessionStorage',
+    isCompatible: (global => {
+      try {
+        const testKey = '_test_'
+        global.sessionStorage.setItem(testKey, testKey)
+        global.sessionStorage.removeItem(testKey)
+        return true
+      } catch (err) {
+        return false
+      }
+    })(global)
+  })
+].map(f => f(window))

--- a/src/EmbededApp/index.js
+++ b/src/EmbededApp/index.js
@@ -1,2 +1,3 @@
 export * from './EmbededAppReporter'
 export * from './EmbededAppContainer'
+export * from './EmbededAppCompatibility'

--- a/src/ErrorPages/NotCompatible.jsx
+++ b/src/ErrorPages/NotCompatible.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+const IncompatibleFeatureMain = styled.div`
+  padding: 2em;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border-radius: 2px 8px 8px 2px;
+  box-shadow: rgba(19, 51, 77, 0.15) 0px 2px 4px;
+  text-align: center;
+`
+
+const IncompatibleFeatureTitle = styled.h1`
+  color: #a0aab2;
+  margin: 0;
+  font-size: 4em;
+`
+
+const IncompatibleFeatureBody = styled.p`
+  color: #333;
+  font-family: sans-serif;
+`
+
+export const NotCompatible = ({ feature }) => (
+  <IncompatibleFeatureMain>
+    <IncompatibleFeatureTitle>&#9888;</IncompatibleFeatureTitle>
+    <IncompatibleFeatureBody
+      dangerouslySetInnerHTML={{
+        __html: incompatibilityMessages[feature.name].de
+      }}></IncompatibleFeatureBody>
+    <IncompatibleFeatureBody
+      dangerouslySetInnerHTML={{
+        __html: incompatibilityMessages[feature.name].en
+      }}></IncompatibleFeatureBody>
+  </IncompatibleFeatureMain>
+)
+
+const incompatibilityMessages = {
+  sessionStorage: {
+    de: `Lieber Etvas Nutzer, unser Marktplatz für Zusatz-Services ist aus technischen Gründen im Inkognitomodus leider nicht verfügbar. Bitte loggen Sie sich im normalen Browserbetrieb in die Plattform ein.`,
+    en: `Dear Etvas user, our marketplace for additional services is unfortunately not available in incognito mode for technical reasons. Please log in to the platform in normal browser mode.`
+  }
+}
+
+NotCompatible.propTypes = {
+  feature: {
+    name: PropTypes.oneOf(['sessionStorage'])
+  }
+}

--- a/src/ErrorPages/index.js
+++ b/src/ErrorPages/index.js
@@ -1,1 +1,2 @@
 export * from './NotFound'
+export * from './NotCompatible'

--- a/stories/ErrorPages.stories.jsx
+++ b/stories/ErrorPages.stories.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { NotFound, Link, Flex, Box, Typography } from '../src'
+import { NotFound, NotCompatible, Link, Flex, Box, Typography } from '../src'
 
 export default {
-  title: 'Demo/ErrorPages/NotFound',
+  title: 'Demo/ErrorPages',
   component: NotFound
 }
 
@@ -17,5 +17,11 @@ export const NotFoundPage = () => (
         </Link>
       </Flex>
     </NotFound>
+  </Box>
+)
+
+export const NotCompatibleIncognito = () => (
+  <Box height='600px'>
+    <NotCompatible feature={{ name: 'sessionStorage' }} />
   </Box>
 )


### PR DESCRIPTION
### Jira: https://etvas.atlassian.net/browse/ETV-2136

### What
- Expose a HOC for embedded apps that checks if the app is compatible - this should be put as high as possible in the DOM

### Why here
- All embedded apps must use this so this seems like the right place for it