### PR TITLE
feat(CardWithImage) Expose background contain type in props

### DIFF
--- a/src/Card/CardWithImage.jsx
+++ b/src/Card/CardWithImage.jsx
@@ -20,6 +20,7 @@ const ContentBox = styled(Box)`
 export const CardWithImage = ({
   imageUrl,
   imageSize,
+  imageContain,
   vertical,
   variant,
   children,
@@ -36,7 +37,7 @@ export const CardWithImage = ({
         width='100%'
         height='100%'>
         <ContentBox vertical={vertical} ratio={imageSize}>
-          <Image url={imageUrl} />
+          <Image url={imageUrl} contain={imageContain} />
         </ContentBox>
         <ContentBox
           vertical={vertical}
@@ -53,12 +54,14 @@ CardWithImage.propTypes = {
   ...Card.propTypes,
   variant: PropTypes.oneOf(['default', 'hero']),
   imageUrl: PropTypes.string.isRequired,
+  imageContain: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
   imageSize: PropTypes.number,
   vertical: PropTypes.bool
 }
 
 CardWithImage.defaultProps = {
   imageSize: 1 / 3,
-  variant: 'default'
+  variant: 'default',
+  imageContain: 'cover'
 }
 CardWithImage.displayName = 'CardWithImage'

--- a/src/Card/CardWithImage.styles.js
+++ b/src/Card/CardWithImage.styles.js
@@ -1,4 +1,4 @@
-import { sm } from '../utils'
+import { sm, md, lg } from '../utils'
 
 const dimensions = (vertical, size) => {
   size = `${size * 100}%`
@@ -10,6 +10,17 @@ const dimensions = (vertical, size) => {
 const borderRadius = vertical => ({
   borderRadius: vertical ? '8px 8px 2px 2px' : '2px 8px 8px 2px'
 })
+
+const imageContain = (value, idx) => {
+  if (!value) {
+    return 'cover'
+  }
+  if (!Array.isArray(value)) {
+    return value
+  }
+
+  return value[idx < value.length - 1 ? idx : value.length - 1]
+}
 
 export default {
   container: ({ theme, vertical }) => ({
@@ -23,14 +34,23 @@ export default {
     ...sm(theme)(dimensions(vertical, ratio))
   }),
 
-  image: ({ url }) => ({
+  image: ({ theme, url, contain }) => ({
     width: '100%',
     height: '100%',
     display: 'block',
-    backgroundSize: 'cover',
+    backgroundSize: imageContain(contain, 0),
     backgroundRepeat: 'no-repeat',
     backgroundPosition: 'center',
     position: 'relative',
-    backgroundImage: `url(${url})`
+    backgroundImage: `url(${url})`,
+    ...sm(theme)({
+      backgroundSize: imageContain(contain, 1)
+    }),
+    ...md(theme)({
+      backgroundSize: imageContain(contain, 2)
+    }),
+    ...lg(theme)({
+      backgroundSize: imageContain(contain, 3)
+    })
   })
 }


### PR DESCRIPTION
Now we can specify the backgroundSize (cover, contain,...) for each breakpoint (as an array with up to 4 strings) or for all (as a string)