### PR TITLE
Make the docs action run on master push

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,8 +1,8 @@
 name: Publish docs
 on:
   push:
-    tags:
-      - v*
+    branches:
+      - master
 jobs:
   publish-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since we do not use the tag functionality anymore, the docs should be updated when we push code to master