### PR TITLE
fix(modal): use mousedown for click handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "ETVAS UI Kit",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -37,7 +37,6 @@ export const Modal = ({
   children,
   ...props
 }) => {
-  const modalRef = useRef()
   const intercom = useRef(new InterCom('etvas.modal'))
 
   const modalBackdropClickHandler = useCallback(() => {
@@ -78,12 +77,8 @@ export const Modal = ({
   }, [handleKeyPress])
 
   return (
-    <StyledModal ref={modalRef} {...props}>
-      <ModalBackdrop
-        bg={backDrop}
-        animated={animated}
-        onClick={modalBackdropClickHandler}
-      />
+    <StyledModal animated={animated} {...props}>
+      <ModalBackdrop bg={backDrop} onClick={modalBackdropClickHandler} />
       {children}
     </StyledModal>
   )

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -86,7 +86,7 @@ export const Modal = ({
       {...props}
       bg={backDrop}
       animated={animated}
-      onClick={modalClickHandler}>
+      onMouseDown={modalClickHandler}>
       {children}
     </StyledModal>
   )

--- a/src/Modal/Modal.jsx
+++ b/src/Modal/Modal.jsx
@@ -27,6 +27,8 @@ const StyledModal = styled(Flex)(
     animation-duration:0.5s;`
 )
 
+const ModalBackdrop = styled(Flex)(css(style.backdrop))
+
 export const Modal = ({
   backDrop,
   onBackDropClick,
@@ -38,14 +40,9 @@ export const Modal = ({
   const modalRef = useRef()
   const intercom = useRef(new InterCom('etvas.modal'))
 
-  const modalClickHandler = useCallback(
-    event => {
-      if (event.target === modalRef.current) {
-        onBackDropClick && onBackDropClick()
-      }
-    },
-    [onBackDropClick]
-  )
+  const modalBackdropClickHandler = useCallback(() => {
+    onBackDropClick && onBackDropClick()
+  }, [onBackDropClick])
   const handleKeyPress = useCallback(
     event => {
       if (event.keyCode === 27) {
@@ -81,12 +78,12 @@ export const Modal = ({
   }, [handleKeyPress])
 
   return (
-    <StyledModal
-      ref={modalRef}
-      {...props}
-      bg={backDrop}
-      animated={animated}
-      onMouseDown={modalClickHandler}>
+    <StyledModal ref={modalRef} {...props}>
+      <ModalBackdrop
+        bg={backDrop}
+        animated={animated}
+        onClick={modalBackdropClickHandler}
+      />
       {children}
     </StyledModal>
   )

--- a/src/Modal/Modal.style.js
+++ b/src/Modal/Modal.style.js
@@ -5,12 +5,17 @@ export default {
     width: '100vw',
     minHeight: '100vh',
     position: 'fixed',
-    zIndex: 'modal',
     overflow: 'scroll'
+  },
+  backdrop: {
+    width: '100vw',
+    minHeight: '100vh',
+    zIndex: 'modal'
   },
   content: {
     position: 'relative',
     display: 'flex',
-    paddingBottom: [3, 9]
+    paddingBottom: [3, 9],
+    zIndex: 'modalContent'
   }
 }

--- a/src/assets/core.js
+++ b/src/assets/core.js
@@ -66,5 +66,6 @@ export const SPACE = range(0, 100, GUTTER)
 
 export const Z_INDICES = {
   menu: 5,
-  modal: 10
+  modal: 10,
+  modalContent: 11
 }


### PR DESCRIPTION
https://etvas.atlassian.net/browse/ETV-4636

A better solution is to make the backdrop be a sibling to the modal content. This way, we are preserving the `onClick` functionality while still fixing the bug.