### PR TITLE
refactor(SubdomainInput): remove default icon

### DIFF
--- a/src/SubdomainInput/SubdomainInput.jsx
+++ b/src/SubdomainInput/SubdomainInput.jsx
@@ -37,6 +37,7 @@ export const SubdomainInput = forwardRef(
       disabled,
       error,
       warning,
+      icRight,
       id,
       label,
       name,
@@ -134,8 +135,9 @@ export const SubdomainInput = forwardRef(
       if (loading) return 'loading'
       else if (error || warning) return 'alertCircle'
       else if (valid) return 'check'
-      return 'check'
-    }, [loading, error, warning, valid])
+
+      return icRight
+    }, [loading, error, warning, valid, icRight])
 
     const currentIcRightColor = useMemo(() => {
       if (loading) return 'brand'

--- a/src/SubdomainInput/SubdomainInput.jsx
+++ b/src/SubdomainInput/SubdomainInput.jsx
@@ -267,7 +267,8 @@ const StatusIcon = styled(Flex)(
 SubdomainInput.propTypes = {
   ...Input.propTypes,
   prefix: PropTypes.string,
-  suffix: PropTypes.string
+  suffix: PropTypes.string,
+  icRight: PropTypes.string
 }
 
 SubdomainInput.defaultProps = {


### PR DESCRIPTION
https://etvas.atlassian.net/browse/ETV-4859

* remove default icon from the subdomain input since we are not using a faded `check` icon anymore as the default and allow for a custom `icRight`
