### PR TITLE
fix(Dropdown): fix active selector too generic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "1.1.48",
+  "version": "1.1.49",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "1.1.48",
+  "version": "1.1.49",
   "description": "ETVAS UI Kit",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -85,9 +85,10 @@ const Dropdown = ({
     [searchPlaceholder, children]
   )
 
-  const cId = useMemo(() => id || `dd-${Math.floor(1000000 * Math.random())}`, [
-    id
-  ])
+  const cId = useMemo(
+    () => id || `dd-${Math.floor(1000000 * Math.random())}`,
+    [id]
+  )
 
   const searchId = useMemo(
     () => `search-${Math.floor(1000000 * Math.random())}`,
@@ -326,7 +327,11 @@ const Dropdown = ({
 }
 
 const StyledFlex = styled(Flex)(
-  css({ '&:focus-within': { label: { color: 'textInputFocused' } } })
+  css({
+    '&:focus-within > div > label': {
+      color: 'textInputFocused'
+    }
+  })
 )
 
 const Toggler = styled.button(


### PR DESCRIPTION
This is need for custom options like buttons to be able to maintain their color while the original behaviour of the dropdown's label remains unchanged