### PR TITLE
Fix option width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "1.1.52",
+  "version": "1.1.53",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "1.1.52",
+  "version": "1.1.53",
   "description": "ETVAS UI Kit",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/Dropdown/Option.jsx
+++ b/src/Dropdown/Option.jsx
@@ -77,7 +77,8 @@ const TextWrapper = styled.div(
   css({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap'
+    whiteSpace: 'nowrap',
+    width: '100%'
   })
 )
 


### PR DESCRIPTION
https://etvas.atlassian.net/browse/ETV-9948
In order for the dropdown option content to be able to have a specific width, the `TextWrapper` component must occupy the whole width of the option container. Currently there is no way to override the width of the `TextWrapper` component, therefore the suggested fix.