### PR TITLE
Add fix for undefined ref

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "1.1.76",
+  "version": "1.1.77",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@etvas/etvaskit",
-      "version": "1.1.76",
+      "version": "1.1.77",
       "license": "MIT",
       "dependencies": {
         "@mdi/js": "^5.8.55",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "1.1.76",
+  "version": "1.1.77",
   "description": "ETVAS UI Kit",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/Input/Input.jsx
+++ b/src/Input/Input.jsx
@@ -117,10 +117,11 @@ export const Input = forwardRef(
       }
 
       if (value) {
-        onChange({ target: { value: '' } })
-      } else {
-        inputRef.current.focus()
+        return onChange({ target: { value: '' } })
       }
+
+      const currentRef = ref || inputRef
+      currentRef.current.focus()
     }
 
     return (


### PR DESCRIPTION
When passing a reference as props to the input component it was ignored and only took into consideration the internal reference of the component. This PR fixes it by making use of both references.
![image](https://github.com/etvascom/etvas-kit/assets/31573322/ef456f56-d448-4e6f-bf56-da6bd6089424)
