### PR TITLE
Fix children type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@etvas/etvaskit",
-      "version": "2.0.38",
+      "version": "2.0.39",
       "license": "MIT",
       "dependencies": {
         "@babel/eslint-parser": "^7.23.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "description": "ETVAS UI Kit",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -1,4 +1,4 @@
-import React, { FC, FormHTMLAttributes, PropsWithChildren } from 'react'
+import React, { FC, FormHTMLAttributes } from 'react'
 
 import { Formik, FormikConfig, Form as FormikForm } from 'formik'
 
@@ -8,11 +8,7 @@ interface Props
   extends Pick<FormHTMLAttributes<HTMLFormElement>, 'name'>,
     FormikConfig<any> {}
 
-export const Form: FC<PropsWithChildren<Props>> = ({
-  name,
-  children,
-  ...props
-}) => {
+export const Form: FC<Props> = ({ name, children, ...props }) => {
   name = name ? `form-${name}` : makeId('form', 'form')
 
   return (


### PR DESCRIPTION
https://etvas.atlassian.net/browse/ETV-12142

### Summary
- removed the default children type from React
- let the children type be inherited from Formik interface