### PR TITLE
fix(CardWithImage): Fix responsiveness of imagesize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "2.0.46",
+  "version": "2.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@etvas/etvaskit",
-      "version": "2.0.46",
+      "version": "2.0.47",
       "license": "MIT",
       "dependencies": {
         "@babel/eslint-parser": "^7.23.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etvas/etvaskit",
-  "version": "2.0.46",
+  "version": "2.0.47",
   "description": "ETVAS UI Kit",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/Card/CardWithImage.styles.ts
+++ b/src/Card/CardWithImage.styles.ts
@@ -18,21 +18,15 @@ export default {
   },
   contentBox: ({ theme, ratio }: { theme: any; ratio: number | number[] }) => ({
     flex: `${1 + _extract(ratio, 0, 0)} 0 ${100 * _extract(ratio, 0, 0)}%`,
-    ...sm(theme)([
-      {
-        flex: `${1 + _extract(ratio, 1, 0)} 0 ${100 * _extract(ratio, 1, 0)}%`
-      }
-    ]),
-    ...md(theme)([
-      {
-        flex: `${1 + _extract(ratio, 2, 0)} 0 ${100 * _extract(ratio, 2, 0)}%`
-      }
-    ]),
-    ...lg(theme)([
-      {
-        flex: `${1 + _extract(ratio, 3, 0)} 0 ${100 * _extract(ratio, 3, 0)}%`
-      }
-    ])
+    ...sm(theme)({
+      flex: `${1 + _extract(ratio, 1, 0)} 0 ${100 * _extract(ratio, 1, 0)}%`
+    }),
+    ...md(theme)({
+      flex: `${1 + _extract(ratio, 2, 0)} 0 ${100 * _extract(ratio, 2, 0)}%`
+    }),
+    ...lg(theme)({
+      flex: `${1 + _extract(ratio, 3, 0)} 0 ${100 * _extract(ratio, 3, 0)}%`
+    })
   }),
   image: ({
     theme,
@@ -51,20 +45,14 @@ export default {
     backgroundPosition: 'center',
     position: 'relative',
     backgroundImage: `url(${url})`,
-    ...sm(theme)([
-      {
-        backgroundSize: _extract(contain, 1, 'cover')
-      }
-    ]),
-    ...md(theme)([
-      {
-        backgroundSize: _extract(contain, 2, 'cover')
-      }
-    ]),
-    ...lg(theme)([
-      {
-        backgroundSize: _extract(contain, 3, 'cover')
-      }
-    ])
+    ...sm(theme)({
+      backgroundSize: _extract(contain, 1, 'cover')
+    }),
+    ...md(theme)({
+      backgroundSize: _extract(contain, 2, 'cover')
+    }),
+    ...lg(theme)({
+      backgroundSize: _extract(contain, 3, 'cover')
+    })
   })
 }

--- a/src/Card/CardWithImage.tsx
+++ b/src/Card/CardWithImage.tsx
@@ -48,16 +48,14 @@ export const CardWithImage: FC<PropsWithChildren<Props>> = ({
         flexDirection={flexDirection}
         justifyContent='space-between'
         width='100%'
-        height='100%'
-      >
+        height='100%'>
         <ContentBox vertical={vertical} ratio={imageSize} p={imagePadding}>
           <Image url={imageUrl} contain={imageContain} />
         </ContentBox>
         <ContentBox
           vertical={vertical}
           p={contentPadding ?? defaultContentPadding}
-          ratio={invImageSize}
-        >
+          ratio={invImageSize}>
           {children}
         </ContentBox>
       </Flex>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,11 +18,11 @@ export const media = (breakpoint: string | number, rules: any[]) => ({
   [`@media (min-width: ${breakpoint})`]: rules
 })
 
-export const sm = (theme: any) => (rules: any[]) =>
+export const sm = (theme: any) => (rules: any | any[]) =>
   media(theme.breakpoints[0], rules)
-export const md = (theme: any) => (rules: any[]) =>
+export const md = (theme: any) => (rules: any | any[]) =>
   media(theme.breakpoints[1], rules)
-export const lg = (theme: any) => (rules: any[]) =>
+export const lg = (theme: any) => (rules: any | any[]) =>
   media(theme.breakpoints[2], rules)
 
 export const {


### PR DESCRIPTION
https://etvas.atlassian.net/browse/ETV-12468

## Problem
Previously when the card received a size array such as `[0.8, 0.6, 0.4]` then the size will always stay the same i.e. `0.8`.
This PR fixes the issue by making the size property work as intended and be responsive.

https://github.com/etvascom/etvas-kit/assets/31573322/5dfdd31a-9681-4b69-8967-75ced24be805

